### PR TITLE
feat: -w command to explicitly add thedependencies to the workspace root

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Install semantic-release extra plugins
-        run: pnpm install --save-dev @semantic-release/changelog @semantic-release/git
+        run: pnpm install --save-dev @semantic-release/changelog @semantic-release/git -w
       - name: Build All Packages
         run: pnpm run build
       - name: Release All Packages


### PR DESCRIPTION
Connected to [APPS-3133](https://jira.library.ucla.edu/browse/APPS-3133)

fix the error 
```
Run pnpm install --save-dev @semantic-release/changelog @semantic-release/git pnpm install --save-dev @semantic-release/changelog @semantic-release/git shell: /usr/bin/bash -e {0} env: PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin  ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root, which might not be what you want - if you really meant it, make it explicit by running this command again with the -w flag (or --workspace-root). If you don't want to see this warning anymore, you may set the ignore-workspace-root-check setting to true. Error: Process completed with exit code 1.
```

[APPS-3133]: https://uclalibrary.atlassian.net/browse/APPS-3133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ